### PR TITLE
feat: Add Transformers.js chat implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@fontsource/bebas-neue": "^5.0.20",
 				"@fontsource/space-grotesk": "^5.0.20",
+				"@xenova/transformers": "^2.17.2",
 				"express": "^5.1.0"
 			},
 			"devDependencies": {
@@ -844,6 +845,70 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/@rollup/plugin-commonjs": {
 			"version": "28.0.6",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
@@ -1410,6 +1475,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/long": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "24.2.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+			"integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.10.0"
+			}
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1807,6 +1887,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@xenova/transformers": {
+			"version": "2.17.2",
+			"resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+			"integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@huggingface/jinja": "^0.2.2",
+				"onnxruntime-web": "1.14.0",
+				"sharp": "^0.32.0"
+			},
+			"optionalDependencies": {
+				"onnxruntime-node": "1.14.0"
+			}
+		},
+		"node_modules/@xenova/transformers/node_modules/@huggingface/jinja": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+			"integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/accepts": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1913,12 +2016,121 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/b4a": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+			"integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bare-events": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+			"integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+			"license": "Apache-2.0",
+			"optional": true
+		},
+		"node_modules/bare-fs": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
+			"integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-os": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+			"integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/bare-stream": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+			"integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"streamx": "^2.21.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
 		},
 		"node_modules/body-parser": {
 			"version": "2.2.0",
@@ -1962,6 +2174,30 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/bytes": {
@@ -2082,6 +2318,12 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"license": "ISC"
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2092,11 +2334,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/color": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1",
+				"color-string": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=12.5.0"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -2109,8 +2363,17 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/color-string": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
 		},
 		"node_modules/commondir": {
 			"version": "1.0.1",
@@ -2211,6 +2474,21 @@
 				}
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/deep-eql": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2219,6 +2497,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/deep-is": {
@@ -2245,6 +2532,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+			"integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/devalue": {
@@ -2281,6 +2577,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -2619,6 +2924,15 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"license": "(MIT OR WTFPL)",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/expect-type": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -2685,6 +2999,12 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -2830,6 +3150,12 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/flatbuffers": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+			"integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+			"license": "SEE LICENSE IN LICENSE.txt"
+		},
 		"node_modules/flatted": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -2854,6 +3180,12 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"license": "MIT"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -2916,6 +3248,12 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"license": "MIT"
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2960,6 +3298,12 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/guid-typescript": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+			"integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+			"license": "ISC"
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -3032,6 +3376,26 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3075,6 +3439,12 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
 		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"license": "ISC"
+		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3083,6 +3453,12 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
@@ -3285,6 +3661,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/long": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/loupe": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
@@ -3390,6 +3772,18 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3402,6 +3796,21 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"license": "MIT"
 		},
 		"node_modules/mri": {
 			"version": "1.2.0",
@@ -3448,6 +3857,12 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/napi-build-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+			"license": "MIT"
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3463,6 +3878,24 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/node-abi": {
+			"version": "3.75.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+			"integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+			"license": "MIT"
 		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
@@ -3495,6 +3928,50 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/onnx-proto": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+			"integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+			"license": "MIT",
+			"dependencies": {
+				"protobufjs": "^6.8.8"
+			}
+		},
+		"node_modules/onnxruntime-common": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+			"integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+			"license": "MIT"
+		},
+		"node_modules/onnxruntime-node": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+			"integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32",
+				"darwin",
+				"linux"
+			],
+			"dependencies": {
+				"onnxruntime-common": "~1.14.0"
+			}
+		},
+		"node_modules/onnxruntime-web": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+			"integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+			"license": "MIT",
+			"dependencies": {
+				"flatbuffers": "^1.12.0",
+				"guid-typescript": "^1.0.9",
+				"long": "^4.0.0",
+				"onnx-proto": "^4.0.4",
+				"onnxruntime-common": "~1.14.0",
+				"platform": "^1.3.6"
 			}
 		},
 		"node_modules/optionator": {
@@ -3642,6 +4119,12 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/platform": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+			"integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+			"license": "MIT"
+		},
 		"node_modules/postcss": {
 			"version": "8.5.6",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -3779,6 +4262,60 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^2.0.0",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/prebuild-install/node_modules/tar-fs": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+			"integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/prebuild-install/node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3816,6 +4353,32 @@
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
 			}
 		},
+		"node_modules/protobufjs": {
+			"version": "6.11.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+			"integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.1",
+				"@types/node": ">=13.7.0",
+				"long": "^4.0.0"
+			},
+			"bin": {
+				"pbjs": "bin/pbjs",
+				"pbts": "bin/pbts"
+			}
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3827,6 +4390,16 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"node_modules/punycode": {
@@ -3897,6 +4470,44 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -4078,7 +4689,6 @@
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
 			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -4136,6 +4746,29 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
 			"license": "ISC"
+		},
+		"node_modules/sharp": {
+			"version": "0.32.6",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+			"integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"color": "^4.2.3",
+				"detect-libc": "^2.0.2",
+				"node-addon-api": "^6.1.0",
+				"prebuild-install": "^7.1.1",
+				"semver": "^7.5.4",
+				"simple-get": "^4.0.1",
+				"tar-fs": "^3.0.4",
+				"tunnel-agent": "^0.6.0"
+			},
+			"engines": {
+				"node": ">=14.15.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -4239,6 +4872,60 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
 		"node_modules/sirv": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
@@ -4286,6 +4973,28 @@
 			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/streamx": {
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+			"integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
+			},
+			"optionalDependencies": {
+				"bare-events": "^2.2.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -4451,6 +5160,40 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/tar-fs": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+			"integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0",
+				"tar-stream": "^3.1.5"
+			},
+			"optionalDependencies": {
+				"bare-fs": "^4.0.1",
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4557,6 +5300,18 @@
 				"typescript": ">=4.8.4"
 			}
 		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4622,6 +5377,12 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+			"license": "MIT"
+		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4645,7 +5406,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
@@ -4923,21 +5683,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"license": "ISC"
-		},
-		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
 		"vitest": "^3.2.3"
 	},
 	"dependencies": {
-		"express": "^5.1.0",
+		"@fontsource/bebas-neue": "^5.0.20",
 		"@fontsource/space-grotesk": "^5.0.20",
-		"@fontsource/bebas-neue": "^5.0.20"
+		"@xenova/transformers": "^2.17.2",
+		"express": "^5.1.0"
 	}
 }

--- a/src/lib/chat-config.ts
+++ b/src/lib/chat-config.ts
@@ -1,12 +1,3 @@
-// Configuration for Wllama
-import singleThreaded from '@wllama/wllama/src/single-thread/wllama.wasm?url';
-import multiThreaded from '@wllama/wllama/src/multi-thread/wllama.wasm?url';
-
-export const WLLAMA_CONFIG_PATHS = {
-	'single-thread/wllama.wasm': singleThreaded,
-	'multi-thread/wllama.wasm': multiThreaded
-};
-
 export const DEFAULT_INFERENCE_PARAMS = {
 	nThreads: -1, // auto
 	nContext: 4096,
@@ -18,8 +9,8 @@ export const DEFAULT_INFERENCE_PARAMS = {
 export const DEFAULT_CHAT_TEMPLATE =
 	"{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}";
 
-// Models available for download
-export const AVAILABLE_MODELS = [
+// Models available for Wllama
+export const WLLAMA_MODELS = [
 	{
 		url: 'https://files.khromov.se/models/google_gemma-3-1b-it-qat-Q4_0.gguf',
 		name: 'Gemma3 1B',
@@ -33,6 +24,14 @@ export const AVAILABLE_MODELS = [
 		size: 386404992
 	}
 ];
+
+// Models available for Transformers.js
+export const TRANSFORMERS_MODELS = [
+    {
+        id: "Xenova/llama-3.2-8b-it-gguf",
+        name: "Llama 3.2 8B",
+    }
+]
 
 export interface Message {
 	role: 'user' | 'assistant' | 'system';

--- a/src/routes/(apps)/+layout.svelte
+++ b/src/routes/(apps)/+layout.svelte
@@ -6,4 +6,12 @@
 	let { children }: Props = $props();
 </script>
 
-{@render children?.()}
+<div class="app-layout">
+	{@render children?.()}
+</div>
+
+<style>
+	.app-layout {
+		padding: 1rem;
+	}
+</style>

--- a/src/routes/(apps)/chat/+page.svelte
+++ b/src/routes/(apps)/chat/+page.svelte
@@ -1,300 +1,25 @@
-<script lang="ts">
-	import { Wllama, type DownloadProgressCallback } from '@wllama/wllama';
-	import { onMount } from 'svelte';
-	import { Template } from '@huggingface/jinja';
-	import {
-		WLLAMA_CONFIG_PATHS,
-		DEFAULT_CHAT_TEMPLATE,
-		AVAILABLE_MODELS,
-		type Message
-	} from '$lib/wllama-config';
-	import { useWakeLock } from '$lib/wakeLock.svelte';
-	import { messages, inferenceParams } from '$lib/stores';
-
-	// Import components
-	import LoadingProgress from '$lib/components/LoadingProgress.svelte';
-	import ErrorDisplay from '$lib/components/ErrorDisplay.svelte';
-	import ModelSelector from '$lib/components/chat/ModelSelector.svelte';
-	import ChatMessages from '$lib/components/chat/ChatMessages.svelte';
-	import MessageInput from '$lib/components/chat/MessageInput.svelte';
-
-	// State variables
-	let wllama: Wllama;
-	let isLoading = $state(false);
-	let isModelLoaded = $state(false);
-	let isGenerating = $state(false);
-	let downloadProgress = $state(0);
-	let previousProgress = $state(0);
-	let downloadError = $state(false);
-	let modelSelection = $state(AVAILABLE_MODELS[0].url);
-	let selectedModel = $state(AVAILABLE_MODELS[0]);
-	let inputText = $state('');
-	let stopSignal = false;
-	let chatMessagesComponent: ChatMessages | undefined = $state();
-	let messageInputComponent: MessageInput | undefined = $state();
-
-	// Initialize wake lock functionality
-	const { requestWakeLock, releaseWakeLock, setupWakeLock } = useWakeLock();
-
-	// Set up event listeners
-	onMount(() => {
-		// Set up wake lock management
-		return setupWakeLock(() => isGenerating);
-	});
-
-	async function loadModel() {
-		try {
-			isLoading = true;
-			downloadError = false;
-			downloadProgress = 0;
-			previousProgress = 0;
-
-			const model = AVAILABLE_MODELS.find((m) => m.url === modelSelection);
-			if (model) {
-				selectedModel = model;
-			}
-
-			wllama = new Wllama(WLLAMA_CONFIG_PATHS);
-
-			const progressCallback: DownloadProgressCallback = ({ loaded, total }) => {
-				previousProgress = downloadProgress;
-				downloadProgress = Math.round((loaded / total) * 100);
-				console.log(`Downloading... ${downloadProgress}%`);
-			};
-
-			await wllama.loadModelFromUrl(modelSelection, {
-				progressCallback,
-				n_threads: $inferenceParams.nThreads > 0 ? $inferenceParams.nThreads : undefined,
-				n_ctx: $inferenceParams.nContext,
-				n_batch: $inferenceParams.nBatch
-			});
-
-			isModelLoaded = true;
-		} catch (err) {
-			console.error('Model loading error:', err);
-			downloadError = true;
-		} finally {
-			isLoading = false;
-		}
-	}
-
-	// Function to generate chat completion
-	async function sendMessage() {
-		if (!isModelLoaded || isGenerating || !inputText.trim()) {
-			return;
-		}
-
-		// Add user message to chat
-		const userMessage: Message = {
-			role: 'user',
-			content: inputText
-		};
-
-		$messages = [...$messages, userMessage];
-
-		// After adding user message, scroll to bottom
-		chatMessagesComponent?.scrollToBottom();
-
-		// Add empty assistant message
-		const assistantMessage: Message = {
-			role: 'assistant',
-			content: ''
-		};
-
-		$messages = [...$messages, assistantMessage];
-
-		// Scroll to see empty assistant message with typing indicator
-		chatMessagesComponent?.scrollToBottom();
-
-		inputText = '';
-		isGenerating = true;
-		stopSignal = false;
-
-		// Request wake lock to keep screen on during generation
-		await requestWakeLock();
-
-		try {
-			// Format chat history for the model
-			let formattedChat = await formatChatHistory($messages.slice(0, -1));
-			console.log('Formatted chat:', formattedChat);
-
-			// Generate completion
-			await wllama.createCompletion(formattedChat, {
-				nPredict: $inferenceParams.nPredict,
-				sampling: {
-					temp: $inferenceParams.temperature
-				},
-				useCache: true,
-				onNewToken: (token, piece, currentText, optionals) => {
-					// Update the last message with the current generated text
-					$messages[$messages.length - 1].content = currentText;
-					$messages = [...$messages];
-
-					// Scroll to bottom with each new token when generating
-					chatMessagesComponent?.scrollToBottom();
-
-					// If stop requested, abort generation
-					if (stopSignal) {
-						optionals.abortSignal();
-					}
-				}
-			});
-		} catch (err) {
-			console.error('Generation error:', err);
-		} finally {
-			isGenerating = false;
-
-			// Release wake lock when generation is complete
-			await releaseWakeLock();
-
-			// Focus the input field when generation is complete
-			messageInputComponent?.focus();
-		}
-	}
-
-	// Function to stop text generation
-	async function stopGeneration() {
-		stopSignal = true;
-
-		// Release wake lock when generation is stopped
-		await releaseWakeLock();
-	}
-
-	// Function to format chat history
-	async function formatChatHistory(msgs: Message[]): Promise<string> {
-		try {
-			const templateStr = wllama.getChatTemplate() || DEFAULT_CHAT_TEMPLATE;
-
-			// Special handling for DeepSeek models that cause issues with jinja
-			const isDeepSeekR1 =
-				templateStr.match(/<｜Assistant｜>/) &&
-				templateStr.match(/<｜User｜>/) &&
-				templateStr.match(/<\/think>/);
-
-			if (isDeepSeekR1) {
-				let result = '';
-				for (const message of msgs) {
-					if (message.role === 'system') {
-						result += `${message.content}\n\n`;
-					} else if (message.role === 'user') {
-						result += `<｜User｜>${message.content}`;
-					} else {
-						result += `<｜Assistant｜>${message.content.split('</think>').pop()}<｜end▁of▁sentence｜>`;
-					}
-				}
-				return result + '<｜Assistant｜>';
-			}
-
-			// Standard template rendering with jinja
-			const template = new Template(templateStr);
-			const bos_token = await wllama.detokenize([wllama.getBOS()], true);
-			const eos_token = await wllama.detokenize([wllama.getEOS()], true);
-
-			return template.render({
-				messages: msgs,
-				bos_token,
-				eos_token,
-				add_generation_prompt: true
-			});
-		} catch (err) {
-			console.error('Error formatting chat:', err);
-			// Fallback to basic formatting
-			return msgs.map((m) => `${m.role}: ${m.content}`).join('\n\n') + '\n\nassistant: ';
-		}
-	}
-
-	// Start fresh chat
-	function newChat() {
-		if (isGenerating) {
-			stopGeneration();
-		}
-		$messages = [];
-
-		// Focus the input field after clearing chat
-		messageInputComponent?.focus();
-	}
-
-	// Initialize on component mount
-	onMount(() => {
-		if ($messages.length === 0) {
-			// Add a system message for first-time users
-			$messages = [
-				{
-					role: 'system',
-					content:
-						"You are a helpful AI assistant. Answer the user's questions concisely and accurately."
-				}
-			];
-		}
-
-		// Focus input when already loaded
-		if (isModelLoaded) {
-			messageInputComponent?.focus();
-		}
-	});
-</script>
-
-{#if !isModelLoaded}
-	<div class="loading">
-		{#if downloadError}
-			<ErrorDisplay
-				message="Failed to load model. Please check your connection and try again."
-				buttonText={isLoading ? 'Reloading...' : 'Reload Model'}
-				onRetry={loadModel}
-				isRetrying={isLoading}
-			/>
-		{:else if isLoading}
-			<LoadingProgress
-				title="Loading Model"
-				progress={downloadProgress}
-				{previousProgress}
-				message="This will take a couple of minutes. The chat model is being downloaded to your browser."
-			/>
-		{:else}
-			<ModelSelector bind:modelSelection onLoadModel={loadModel} {isLoading} />
-		{/if}
+<div class="selection-page">
+	<h1>Choose a Chat Model</h1>
+	<div class="options">
+		<a href="/chat/wllama" class="option-card">
+			<h2>Wllama</h2>
+			<p>Run chat models using GGUF format with Wllama.</p>
+		</a>
+		<a href="/chat/transformers" class="option-card">
+			<h2>Transformers.js</h2>
+			<p>Run chat models from Hugging Face with Transformers.js.</p>
+		</a>
 	</div>
-{:else}
-	<div class="card-interface chat-interface">
-		<div class="floating-decoration decoration-1"></div>
-		<div class="floating-decoration decoration-2"></div>
-
-		<div class="toolbar">
-			<span class="model-info">
-				<span class="model-emoji">🤖</span>
-				{selectedModel.name}
-			</span>
-			<button onclick={newChat} class="new-chat-btn" aria-label="New Chat">
-				<span class="btn-emoji">✨</span>
-				New <span class="desktop-only">Chat</span>
-			</button>
-			<div class="toolbar-decoration"></div>
-		</div>
-
-		<ChatMessages bind:this={chatMessagesComponent} messages={$messages} {isGenerating} />
-
-		<MessageInput
-			bind:this={messageInputComponent}
-			bind:value={inputText}
-			{isGenerating}
-			onSend={sendMessage}
-			onStop={stopGeneration}
-		/>
-	</div>
-{/if}
+</div>
 
 <style>
-	.loading {
+	.selection-page {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		gap: 2rem;
 		margin: 2rem 0;
 		animation: fadeIn 0.4s ease-out;
-		width: 100%;
-		box-sizing: border-box;
-		overflow-x: hidden;
-		padding: 0;
 	}
 
 	@keyframes fadeIn {
@@ -308,152 +33,23 @@
 		}
 	}
 
-	.chat-interface {
-		position: relative;
-		transform: rotate(0deg);
-		animation: slideInChat 0.5s ease-out;
+	.options {
 		display: flex;
-		flex-direction: column;
-		/* Fix the card height relative to the viewport so only the messages list scrolls */
-		height: clamp(520px, 85vh, 920px);
-		min-height: 0; /* important for inner flex child scrolling */
+		gap: 2rem;
 	}
 
-	@media (max-width: 600px) {
-		.chat-interface {
-			height: 85vh;
-		}
-	}
-
-	@keyframes slideInChat {
-		from {
-			opacity: 0;
-			transform: translateY(20px) rotate(0deg);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0) rotate(0deg);
-		}
-	}
-
-	.floating-decoration {
-		position: absolute;
-		background: linear-gradient(135deg, #ffd93d 0%, #ff69b4 100%);
-		border: 3px solid #000;
-		opacity: 0.2;
-		z-index: -1;
-		pointer-events: none;
-	}
-
-	.decoration-1 {
-		width: 80px;
-		height: 80px;
-		top: -20px;
-		right: -20px;
-		border-radius: 30% 70% 70% 30% / 60% 40% 60% 40%;
-		animation: float1 8s ease-in-out infinite;
-	}
-
-	.decoration-2 {
-		width: 60px;
-		height: 60px;
-		bottom: 100px;
-		left: -15px;
-		border-radius: 70% 30% 30% 70% / 40% 60% 40% 60%;
-		animation: float2 10s ease-in-out infinite;
-	}
-
-	@keyframes float1 {
-		0%,
-		100% {
-			transform: translate(0, 0) rotate(0deg);
-		}
-		50% {
-			transform: translate(-10px, 10px) rotate(180deg);
-		}
-	}
-
-	@keyframes float2 {
-		0%,
-		100% {
-			transform: translate(0, 0) rotate(0deg);
-		}
-		50% {
-			transform: translate(10px, -10px) rotate(-180deg);
-		}
-	}
-
-	.toolbar-decoration {
-		position: absolute;
-		bottom: -6px;
-		left: 0;
-		right: 0;
-		height: 3px;
-		background: repeating-linear-gradient(90deg, #000, #000 8px, #98fb98 8px, #98fb98 16px);
-	}
-
-	.model-emoji {
-		font-size: 1.125rem;
-		margin-right: 0.25rem;
-	}
-
-	.btn-emoji {
-		font-size: 1rem;
-	}
-
-	.new-chat-btn {
-		padding: 0.5rem 1rem;
-		background: #98fb98;
-		color: #000;
+	.option-card {
 		border: 2px solid #000;
-		border-radius: 6px;
-		cursor: pointer;
-		font-size: 0.875rem;
-		font-weight: 700;
+		border-radius: 8px;
+		padding: 2rem;
+		text-align: center;
 		transition: all 0.2s;
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
-		font-family: 'Space Grotesk', system-ui, sans-serif;
-		white-space: nowrap;
-		box-shadow: 3px 3px 0 #000;
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-		transform: rotate(0deg);
+		text-decoration: none;
+		color: inherit;
 	}
 
-	.new-chat-btn:hover {
-		transform: translate(-2px, -2px) rotate(0deg);
-		box-shadow: 5px 5px 0 #000;
-		background: #ffd93d;
-	}
-
-	/* Responsive adjustments for the main page */
-	@media (max-width: 600px) {
-		.loading {
-			align-items: stretch;
-			margin: 1rem 0;
-		}
-
-		.new-chat-btn {
-			padding: 0.375rem 0.75rem;
-			font-size: 0.8125rem;
-		}
-
-		/* Hide the extra word on small screens */
-		.desktop-only {
-			display: none;
-		}
-
-		.decoration-1,
-		.decoration-2 {
-			display: none;
-		}
-	}
-
-	@media (max-width: 400px) {
-		.loading {
-			margin: 0.5rem 0;
-		}
+	.option-card:hover {
+		transform: translateY(-5px);
+		box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
 	}
 </style>

--- a/src/routes/(apps)/chat/transformers/+page.svelte
+++ b/src/routes/(apps)/chat/transformers/+page.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pipeline, type TextGenerationPipeline } from '@xenova/transformers';
+	import { messages, inferenceParams } from '$lib/stores';
+	import type { Message } from '$lib/chat-config';
+
+	// Import components
+	import LoadingProgress from '$lib/components/LoadingProgress.svelte';
+	import ErrorDisplay from '$lib/components/ErrorDisplay.svelte';
+	import ChatMessages from '$lib/components/chat/ChatMessages.svelte';
+	import MessageInput from '$lib/components/chat/MessageInput.svelte';
+
+	// State variables
+	let generator: TextGenerationPipeline;
+	let isLoading = $state(true);
+	let isModelLoaded = $state(false);
+	let isGenerating = $state(false);
+	let downloadProgress = $state(0);
+	let previousProgress = $state(0);
+	let downloadError = $state(false);
+	let inputText = $state('');
+	let stopSignal = false;
+	let chatMessagesComponent: ChatMessages | undefined = $state();
+	let messageInputComponent: MessageInput | undefined = $state();
+
+	const MODEL = "Xenova/llama-3.2-8b-it-gguf";
+	const QUANTIZED_MODEL = "Xenova/llama-3.2-8b-it-gguf";
+
+	onMount(async () => {
+		await loadModel();
+	});
+
+	async function loadModel() {
+		try {
+			isLoading = true;
+			downloadError = false;
+			downloadProgress = 0;
+			previousProgress = 0;
+
+			generator = await pipeline('text-generation', QUANTIZED_MODEL, {
+				progress_callback: (progress: any) => {
+					previousProgress = downloadProgress;
+					downloadProgress = Math.round(progress.progress);
+					console.log(`Downloading... ${downloadProgress}%`);
+				},
+			});
+
+			isModelLoaded = true;
+		} catch (err) {
+			console.error('Model loading error:', err);
+			downloadError = true;
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function sendMessage() {
+		if (!isModelLoaded || isGenerating || !inputText.trim()) {
+			return;
+		}
+
+		const userMessage: Message = { role: 'user', content: inputText };
+		$messages = [...$messages, userMessage];
+		chatMessagesComponent?.scrollToBottom();
+
+		const assistantMessage: Message = { role: 'assistant', content: '' };
+		$messages = [...$messages, assistantMessage];
+		chatMessagesComponent?.scrollToBottom();
+
+		inputText = '';
+		isGenerating = true;
+		stopSignal = false;
+
+		const stream = await generator($messages, {
+			max_new_tokens: $inferenceParams.nPredict,
+			temperature: $inferenceParams.temperature,
+			do_sample: $inferenceParams.temperature > 0,
+		});
+
+		for await (const chunk of stream) {
+			if (stopSignal) {
+				generator.dispose();
+				loadModel(); // To re-initialize the generator
+				break;
+			}
+			const outputToken = chunk;
+			$messages[$messages.length - 1].content += outputToken;
+			$messages = [...$messages];
+			chatMessagesComponent?.scrollToBottom();
+		}
+
+		isGenerating = false;
+		messageInputComponent?.focus();
+	}
+
+	function newChat() {
+		if (isGenerating) {
+			stopSignal = true;
+		}
+		$messages = [];
+		messageInputComponent?.focus();
+	}
+
+	onMount(() => {
+		if ($messages.length === 0) {
+			$messages = [
+				{
+					role: 'system',
+					content: "You are a helpful AI assistant. Answer the user's questions concisely and accurately."
+				}
+			];
+		}
+		if (isModelLoaded) {
+			messageInputComponent?.focus();
+		}
+	});
+</script>
+
+{#if !isModelLoaded}
+	<div class="loading">
+		{#if downloadError}
+			<ErrorDisplay
+				message="Failed to load model. Please check your connection and try again."
+				buttonText={isLoading ? 'Reloading...' : 'Reload Model'}
+				onRetry={loadModel}
+				isRetrying={isLoading}
+			/>
+		{:else if isLoading}
+			<LoadingProgress
+				title="Loading Model"
+				progress={downloadProgress}
+				{previousProgress}
+				message="This will take a couple of minutes. The chat model is being downloaded to your browser."
+			/>
+		{:else}
+			<!-- Empty else block for now -->
+		{/if}
+	</div>
+{:else}
+	<div class="card-interface chat-interface">
+		<div class="floating-decoration decoration-1"></div>
+		<div class="floating-decoration decoration-2"></div>
+
+		<div class="toolbar">
+			<span class="model-info">
+				<span class="model-emoji">🤖</span>
+				Llama 3.2 8B (Transformers.js)
+			</span>
+			<button onclick={newChat} class="new-chat-btn" aria-label="New Chat">
+				<span class="btn-emoji">✨</span>
+				New <span class="desktop-only">Chat</span>
+			</button>
+			<div class="toolbar-decoration"></div>
+		</div>
+
+		<ChatMessages bind:this={chatMessagesComponent} messages={$messages} {isGenerating} />
+
+		<MessageInput
+			bind:this={messageInputComponent}
+			bind:value={inputText}
+			{isGenerating}
+			onSend={sendMessage}
+			onStop={() => stopSignal = true}
+		/>
+	</div>
+{/if}
+
+<style>
+	.loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2rem;
+		margin: 2rem 0;
+		animation: fadeIn 0.4s ease-out;
+		width: 100%;
+		box-sizing: border-box;
+		overflow-x: hidden;
+		padding: 0;
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+			transform: translateY(20px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	.chat-interface {
+		position: relative;
+		transform: rotate(0deg);
+		animation: slideInChat 0.5s ease-out;
+		display: flex;
+		flex-direction: column;
+		/* Fix the card height relative to the viewport so only the messages list scrolls */
+		height: clamp(520px, 85vh, 920px);
+		min-height: 0; /* important for inner flex child scrolling */
+	}
+
+	@media (max-width: 600px) {
+		.chat-interface {
+			height: 85vh;
+		}
+	}
+
+	@keyframes slideInChat {
+		from {
+			opacity: 0;
+			transform: translateY(20px) rotate(0deg);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0) rotate(0deg);
+		}
+	}
+
+	.floating-decoration {
+		position: absolute;
+		background: linear-gradient(135deg, #ffd93d 0%, #ff69b4 100%);
+		border: 3px solid #000;
+		opacity: 0.2;
+		z-index: -1;
+		pointer-events: none;
+	}
+
+	.decoration-1 {
+		width: 80px;
+		height: 80px;
+		top: -20px;
+		right: -20px;
+		border-radius: 30% 70% 70% 30% / 60% 40% 60% 40%;
+		animation: float1 8s ease-in-out infinite;
+	}
+
+	.decoration-2 {
+		width: 60px;
+		height: 60px;
+		bottom: 100px;
+		left: -15px;
+		border-radius: 70% 30% 30% 70% / 40% 60% 40% 60%;
+		animation: float2 10s ease-in-out infinite;
+	}
+
+	@keyframes float1 {
+		0%,
+		100% {
+			transform: translate(0, 0) rotate(0deg);
+		}
+		50% {
+			transform: translate(-10px, 10px) rotate(180deg);
+		}
+	}
+
+	@keyframes float2 {
+		0%,
+		100% {
+			transform: translate(0, 0) rotate(0deg);
+		}
+		50% {
+			transform: translate(10px, -10px) rotate(-180deg);
+		}
+	}
+
+	.toolbar-decoration {
+		position: absolute;
+		bottom: -6px;
+		left: 0;
+		right: 0;
+		height: 3px;
+		background: repeating-linear-gradient(90deg, #000, #000 8px, #98fb98 8px, #98fb98 16px);
+	}
+
+	.model-emoji {
+		font-size: 1.125rem;
+		margin-right: 0.25rem;
+	}
+
+	.btn-emoji {
+		font-size: 1rem;
+	}
+
+	.new-chat-btn {
+		padding: 0.5rem 1rem;
+		background: #98fb98;
+		color: #000;
+		border: 2px solid #000;
+		border-radius: 6px;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 700;
+		transition: all 0.2s;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		font-family: 'Space Grotesk', system-ui, sans-serif;
+		white-space: nowrap;
+		box-shadow: 3px 3px 0 #000;
+		display: flex;
+		align-items/center;
+		gap: 0.375rem;
+		transform: rotate(0deg);
+	}
+
+	.new-chat-btn:hover {
+		transform: translate(-2px, -2px) rotate(0deg);
+		box-shadow: 5px 5px 0 #000;
+		background: #ffd93d;
+	}
+
+	/* Responsive adjustments for the main page */
+	@media (max-width: 600px) {
+.loading {
+			align-items: stretch;
+			margin: 1rem 0;
+		}
+
+		.new-chat-btn {
+			padding: 0.375rem 0.75rem;
+			font-size: 0.8125rem;
+		}
+
+		/* Hide the extra word on small screens */
+		.desktop-only {
+			display: none;
+		}
+
+		.decoration-1,
+		.decoration-2 {
+			display: none;
+		}
+	}
+
+	@media (max-width: 400px) {
+		.loading {
+			margin: 0.5rem 0;
+		}
+	}
+</style>

--- a/src/routes/(apps)/chat/wllama/+page.svelte
+++ b/src/routes/(apps)/chat/wllama/+page.svelte
@@ -1,0 +1,465 @@
+<script lang="ts">
+	import { Wllama, type DownloadProgressCallback } from '@wllama/wllama';
+	import { onMount } from 'svelte';
+	import { Template } from '@huggingface/jinja';
+	import {
+		DEFAULT_CHAT_TEMPLATE,
+		WLLAMA_MODELS as AVAILABLE_MODELS,
+		type Message
+	} from '$lib/chat-config';
+	import singleThreaded from '@wllama/wllama/src/single-thread/wllama.wasm?url';
+	import multiThreaded from '@wllama/wllama/src/multi-thread/wllama.wasm?url';
+
+	export const WLLAMA_CONFIG_PATHS = {
+		'single-thread/wllama.wasm': singleThreaded,
+		'multi-thread/wllama.wasm': multiThreaded
+	};
+	import { useWakeLock } from '$lib/wakeLock.svelte';
+	import { messages, inferenceParams } from '$lib/stores';
+
+	// Import components
+	import LoadingProgress from '$lib/components/LoadingProgress.svelte';
+	import ErrorDisplay from '$lib/components/ErrorDisplay.svelte';
+	import ModelSelector from '$lib/components/chat/ModelSelector.svelte';
+	import ChatMessages from '$lib/components/chat/ChatMessages.svelte';
+	import MessageInput from '$lib/components/chat/MessageInput.svelte';
+
+	// State variables
+	let wllama: Wllama;
+	let isLoading = $state(false);
+	let isModelLoaded = $state(false);
+	let isGenerating = $state(false);
+	let downloadProgress = $state(0);
+	let previousProgress = $state(0);
+	let downloadError = $state(false);
+	let modelSelection = $state(AVAILABLE_MODELS[0].url);
+	let selectedModel = $state(AVAILABLE_MODELS[0]);
+	let inputText = $state('');
+	let stopSignal = false;
+	let chatMessagesComponent: ChatMessages | undefined = $state();
+	let messageInputComponent: MessageInput | undefined = $state();
+
+	// Initialize wake lock functionality
+	const { requestWakeLock, releaseWakeLock, setupWakeLock } = useWakeLock();
+
+	// Set up event listeners
+	onMount(() => {
+		// Set up wake lock management
+		return setupWakeLock(() => isGenerating);
+	});
+
+	async function loadModel() {
+		try {
+			isLoading = true;
+			downloadError = false;
+			downloadProgress = 0;
+			previousProgress = 0;
+
+			const model = AVAILABLE_MODELS.find((m) => m.url === modelSelection);
+			if (model) {
+				selectedModel = model;
+			}
+
+			wllama = new Wllama(WLLAMA_CONFIG_PATHS);
+
+			const progressCallback: DownloadProgressCallback = ({ loaded, total }) => {
+				previousProgress = downloadProgress;
+				downloadProgress = Math.round((loaded / total) * 100);
+				console.log(`Downloading... ${downloadProgress}%`);
+			};
+
+			await wllama.loadModelFromUrl(modelSelection, {
+				progressCallback,
+				n_threads: $inferenceParams.nThreads > 0 ? $inferenceParams.nThreads : undefined,
+				n_ctx: $inferenceParams.nContext,
+				n_batch: $inferenceParams.nBatch
+			});
+
+			isModelLoaded = true;
+		} catch (err) {
+			console.error('Model loading error:', err);
+			downloadError = true;
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	// Function to generate chat completion
+	async function sendMessage() {
+		if (!isModelLoaded || isGenerating || !inputText.trim()) {
+			return;
+		}
+
+		// Add user message to chat
+		const userMessage: Message = {
+			role: 'user',
+			content: inputText
+		};
+
+		$messages = [...$messages, userMessage];
+
+		// After adding user message, scroll to bottom
+		chatMessagesComponent?.scrollToBottom();
+
+		// Add empty assistant message
+		const assistantMessage: Message = {
+			role: 'assistant',
+			content: ''
+		};
+
+		$messages = [...$messages, assistantMessage];
+
+		// Scroll to see empty assistant message with typing indicator
+		chatMessagesComponent?.scrollToBottom();
+
+		inputText = '';
+		isGenerating = true;
+		stopSignal = false;
+
+		// Request wake lock to keep screen on during generation
+		await requestWakeLock();
+
+		try {
+			// Format chat history for the model
+			let formattedChat = await formatChatHistory($messages.slice(0, -1));
+			console.log('Formatted chat:', formattedChat);
+
+			// Generate completion
+			await wllama.createCompletion(formattedChat, {
+				nPredict: $inferenceParams.nPredict,
+				sampling: {
+					temp: $inferenceParams.temperature
+				},
+				useCache: true,
+				onNewToken: (token, piece, currentText, optionals) => {
+					// Update the last message with the current generated text
+					$messages[$messages.length - 1].content = currentText;
+					$messages = [...$messages];
+
+					// Scroll to bottom with each new token when generating
+					chatMessagesComponent?.scrollToBottom();
+
+					// If stop requested, abort generation
+					if (stopSignal) {
+						optionals.abortSignal();
+					}
+				}
+			});
+		} catch (err) {
+			console.error('Generation error:', err);
+		} finally {
+			isGenerating = false;
+
+			// Release wake lock when generation is complete
+			await releaseWakeLock();
+
+			// Focus the input field when generation is complete
+			messageInputComponent?.focus();
+		}
+	}
+
+	// Function to stop text generation
+	async function stopGeneration() {
+		stopSignal = true;
+
+		// Release wake lock when generation is stopped
+		await releaseWakeLock();
+	}
+
+	// Function to format chat history
+	async function formatChatHistory(msgs: Message[]): Promise<string> {
+		try {
+			const templateStr = wllama.getChatTemplate() || DEFAULT_CHAT_TEMPLATE;
+
+			// Special handling for DeepSeek models that cause issues with jinja
+			const isDeepSeekR1 =
+				templateStr.match(/<｜Assistant｜>/) &&
+				templateStr.match(/<｜User｜>/) &&
+				templateStr.match(/<\/think>/);
+
+			if (isDeepSeekR1) {
+				let result = '';
+				for (const message of msgs) {
+					if (message.role === 'system') {
+						result += `${message.content}\n\n`;
+					} else if (message.role === 'user') {
+						result += `<｜User｜>${message.content}`;
+					} else {
+						result += `<｜Assistant｜>${message.content.split('</think>').pop()}<｜end of sentence｜>`;
+					}
+				}
+				return result + '<｜Assistant｜>';
+			}
+
+			// Standard template rendering with jinja
+			const template = new Template(templateStr);
+			const bos_token = await wllama.detokenize([wllama.getBOS()], true);
+			const eos_token = await wllama.detokenize([wllama.getEOS()], true);
+
+			return template.render({
+				messages: msgs,
+				bos_token,
+				eos_token,
+				add_generation_prompt: true
+			});
+		} catch (err) {
+			console.error('Error formatting chat:', err);
+			// Fallback to basic formatting
+			return msgs.map((m) => `${m.role}: ${m.content}`).join('\n\n') + '\n\nassistant: ';
+		}
+	}
+
+	// Start fresh chat
+	function newChat() {
+		if (isGenerating) {
+			stopGeneration();
+		}
+		$messages = [];
+
+		// Focus the input field after clearing chat
+		messageInputComponent?.focus();
+	}
+
+	// Initialize on component mount
+	onMount(() => {
+		if ($messages.length === 0) {
+			// Add a system message for first-time users
+			$messages = [
+				{
+					role: 'system',
+					content:
+						"You are a helpful AI assistant. Answer the user's questions concisely and accurately."
+				}
+			];
+		}
+
+		// Focus input when already loaded
+		if (isModelLoaded) {
+			messageInputComponent?.focus();
+		}
+	});
+</script>
+
+{#if !isModelLoaded}
+	<div class="loading">
+		{#if downloadError}
+			<ErrorDisplay
+				message="Failed to load model. Please check your connection and try again."
+				buttonText={isLoading ? 'Reloading...' : 'Reload Model'}
+				onRetry={loadModel}
+				isRetrying={isLoading}
+			/>
+		{:else if isLoading}
+			<LoadingProgress
+				title="Loading Model"
+				progress={downloadProgress}
+				{previousProgress}
+				message="This will take a couple of minutes. The chat model is being downloaded to your browser."
+			/>
+		{:else}
+			<ModelSelector bind:modelSelection onLoadModel={loadModel} {isLoading} />
+		{/if}
+	</div>
+{:else}
+	<div class="card-interface chat-interface">
+		<div class="floating-decoration decoration-1"></div>
+		<div class="floating-decoration decoration-2"></div>
+
+		<div class="toolbar">
+			<span class="model-info">
+				<span class="model-emoji">🤖</span>
+				{selectedModel.name}
+			</span>
+			<button onclick={newChat} class="new-chat-btn" aria-label="New Chat">
+				<span class="btn-emoji">✨</span>
+				New <span class="desktop-only">Chat</span>
+			</button>
+			<div class="toolbar-decoration"></div>
+		</div>
+
+		<ChatMessages bind:this={chatMessagesComponent} messages={$messages} {isGenerating} />
+
+		<MessageInput
+			bind:this={messageInputComponent}
+			bind:value={inputText}
+			{isGenerating}
+			onSend={sendMessage}
+			onStop={stopGeneration}
+		/>
+	</div>
+{/if}
+
+<style>
+	.loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2rem;
+		margin: 2rem 0;
+		animation: fadeIn 0.4s ease-out;
+		width: 100%;
+		box-sizing: border-box;
+		overflow-x: hidden;
+		padding: 0;
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+			transform: translateY(20px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	.chat-interface {
+		position: relative;
+		transform: rotate(0deg);
+		animation: slideInChat 0.5s ease-out;
+		display: flex;
+		flex-direction: column;
+		/* Fix the card height relative to the viewport so only the messages list scrolls */
+		height: clamp(520px, 85vh, 920px);
+		min-height: 0; /* important for inner flex child scrolling */
+	}
+
+	@media (max-width: 600px) {
+		.chat-interface {
+			height: 85vh;
+		}
+	}
+
+	@keyframes slideInChat {
+		from {
+			opacity: 0;
+			transform: translateY(20px) rotate(0deg);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0) rotate(0deg);
+		}
+	}
+
+	.floating-decoration {
+		position: absolute;
+		background: linear-gradient(135deg, #ffd93d 0%, #ff69b4 100%);
+		border: 3px solid #000;
+		opacity: 0.2;
+		z-index: -1;
+		pointer-events: none;
+	}
+
+	.decoration-1 {
+		width: 80px;
+		height: 80px;
+		top: -20px;
+		right: -20px;
+		border-radius: 30% 70% 70% 30% / 60% 40% 60% 40%;
+		animation: float1 8s ease-in-out infinite;
+	}
+
+	.decoration-2 {
+		width: 60px;
+		height: 60px;
+		bottom: 100px;
+		left: -15px;
+		border-radius: 70% 30% 30% 70% / 40% 60% 40% 60%;
+		animation: float2 10s ease-in-out infinite;
+	}
+
+	@keyframes float1 {
+		0%,
+		100% {
+			transform: translate(0, 0) rotate(0deg);
+		}
+		50% {
+			transform: translate(-10px, 10px) rotate(180deg);
+		}
+	}
+
+	@keyframes float2 {
+		0%,
+		100% {
+			transform: translate(0, 0) rotate(0deg);
+		}
+		50% {
+			transform: translate(10px, -10px) rotate(-180deg);
+		}
+	}
+
+	.toolbar-decoration {
+		position: absolute;
+		bottom: -6px;
+		left: 0;
+		right: 0;
+		height: 3px;
+		background: repeating-linear-gradient(90deg, #000, #000 8px, #98fb98 8px, #98fb98 16px);
+	}
+
+	.model-emoji {
+		font-size: 1.125rem;
+		margin-right: 0.25rem;
+	}
+
+	.btn-emoji {
+		font-size: 1rem;
+	}
+
+	.new-chat-btn {
+		padding: 0.5rem 1rem;
+		background: #98fb98;
+		color: #000;
+		border: 2px solid #000;
+		border-radius: 6px;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 700;
+		transition: all 0.2s;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		font-family: 'Space Grotesk', system-ui, sans-serif;
+		white-space: nowrap;
+		box-shadow: 3px 3px 0 #000;
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		transform: rotate(0deg);
+	}
+
+	.new-chat-btn:hover {
+		transform: translate(-2px, -2px) rotate(0deg);
+		box-shadow: 5px 5px 0 #000;
+		background: #ffd93d;
+	}
+
+	/* Responsive adjustments for the main page */
+	@media (max-width: 600px) {
+		.loading {
+			align-items: stretch;
+			margin: 1rem 0;
+		}
+
+		.new-chat-btn {
+			padding: 0.375rem 0.75rem;
+			font-size: 0.8125rem;
+		}
+
+		/* Hide the extra word on small screens */
+		.desktop-only {
+			display: none;
+		}
+
+		.decoration-1,
+		.decoration-2 {
+			display: none;
+		}
+	}
+
+	@media (max-width: 400px) {
+		.loading {
+			margin: 0.5rem 0;
+		}
+	}
+</style>


### PR DESCRIPTION
This commit adds support for using Transformers.js as an alternative to Wllama for the chat functionality.

A selection page is added at `/chat` to allow you to choose between the two implementations.

- The Wllama implementation is moved to `/chat/wllama`.
- The new Transformers.js implementation is at `/chat/transformers`.
- The configuration has been generalized to support both.